### PR TITLE
Remove ip_addr.h include

### DIFF
--- a/uDevice.cpp
+++ b/uDevice.cpp
@@ -55,10 +55,10 @@ uDevice::~uDevice(){
   os_free(_manufacturerURL);
 }
 
-char *uDevice::uuid(){
-  char *_uuid = (char*)os_malloc(37);
+String uDevice::uuid(){
+  char _uuid[37];
   sprintf(_uuid, "%s-%02X%02X%02X%02X%02X%02X", _base, _mac[0], _mac[1], _mac[2], _mac[3], _mac[4], _mac[5]);
-	return _uuid;
+  return String(_uuid);
 }
 
 

--- a/uDevice.h
+++ b/uDevice.h
@@ -35,7 +35,7 @@ class uDevice{
       begin(base, mac, BASIC);
     }
     
-    char *uuid();
+    String uuid();
 
     device_t deviceType();
     void deviceType(device_t deviceType);

--- a/uSSDP.cpp
+++ b/uSSDP.cpp
@@ -7,7 +7,6 @@
 #include "uSSDP.h"
 
 extern "C" {
-#include "ip_addr.h"
 #include "user_interface.h"
 }
 #include "lwip/igmp.h"


### PR DESCRIPTION
Hi,

When using uSSDP with ESP8266 in platformIO (not sure if it happens in ArduinoIDE) There are errors about redefinitions/conflicts.

`
In file included from .piolibdeps\uSSDP\uSSDP.cpp:10:0:
C:\Users\Thomas\.platformio\packages\framework-arduinoespressif8266\tools\sdk\include/ip_addr.h:34:8: error: redefinition of 'struct ip_addr'
`

I think it's because ip_addr.h  is also included in user_interface, but it is the "lwip" version?  
`.platformio\packages\framework-arduinoespressif8266\tools\sdk\lwip2\include/lwip/ip_addr.h`
(vs the include in uSSDP.cpp line 10 which I think is including 
`framework-arduinoespressif8266\tools\sdk\include/ip_addr.h`

Since user_interface already includes ip_addr.h I think it's not needed to include it in uSSDP.cpp directly. 

Also, would it be possible to enable issues etc on this repo? :) Thanks!